### PR TITLE
Update index.js to strapi 3.1.3.

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -26,17 +26,19 @@ export default strapi => {
     name: pluginPkg.strapi.name,
     preventComponentRendering: false,
     settings: {
-      global: [
-        {
-          title: {
-            id: getTrad('plugin.name'),
-            defaultMessage: 'Responsive image',
+      global: {
+        links: [
+          {
+            title: {
+              id: getTrad('plugin.name'),
+              defaultMessage: 'Responsive image',
+            },
+            name: 'responsive-image',
+            to: `${strapi.settingsBaseURL}/responsive-image`,
+            Component: SettingsPage,
           },
-          name: 'responsive-image',
-          to: `${strapi.settingsBaseURL}/responsive-image`,
-          Component: SettingsPage,
-        },
-      ],
+        ],
+      },
     },
     trads,
   };


### PR DESCRIPTION
It shows the plugin in global settings.

This solves the next bug https://github.com/nicolashmln/strapi-plugin-responsive-image/issues/2. Also, it may require additional permissions, see this example https://github.com/strapi/strapi/blob/master/packages/strapi-plugin-upload/admin/src/permissions.js.