### PR TITLE
Add option to convert image format to jpg, png or webp.

### DIFF
--- a/admin/src/containers/Settings/ImageFormat.js
+++ b/admin/src/containers/Settings/ImageFormat.js
@@ -10,7 +10,7 @@ const ImageFormat = (props) => {
 
   const fitList = ['cover', 'contain', 'fill', 'inside', 'outside'];
   const positionList = ['centre', 'center', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'northwest']
-  const convertToFormatList = ['', 'jpeg', 'png', 'webp']
+  const convertToFormatList = ['', 'jpeg', 'png', 'webp', 'avif']
 
   const input = props.format;
   const handleFormatsChange = props.handleFormatsChange;

--- a/admin/src/containers/Settings/ImageFormat.js
+++ b/admin/src/containers/Settings/ImageFormat.js
@@ -10,6 +10,7 @@ const ImageFormat = (props) => {
 
   const fitList = ['cover', 'contain', 'fill', 'inside', 'outside'];
   const positionList = ['centre', 'center', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west', 'northwest']
+  const convertToFormatList = ['', 'jpeg', 'png', 'webp']
 
   const input = props.format;
   const handleFormatsChange = props.handleFormatsChange;
@@ -43,7 +44,7 @@ const ImageFormat = (props) => {
           value={input.name}
         />
       </div>
-      <div className="col-6">
+      <div className="col-3">
         <Inputs
           label={formatMessage({
             id: getTrad('settings.form.formats.x2.label'),
@@ -53,6 +54,21 @@ const ImageFormat = (props) => {
           onChange={(target) => handleFormatsChange(target, index)}
           type="bool"
           value={input.x2}
+        />
+      </div>
+      <div className="col-3">
+        <Inputs
+          label={formatMessage({
+            id: getTrad('settings.form.formats.convertToFormat.label'),
+          })}
+          description={formatMessage({
+            id: getTrad('settings.form.formats.convertToFormat.description'),
+          })}
+          name="convertToFormat"
+          onChange={(target) => handleFormatsChange(target, index)}
+          type="select"
+          options={convertToFormatList}
+          value={input.convertToFormat}
         />
       </div>
       <div className="col-6">

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -10,6 +10,8 @@
   "settings.form.formats.name.label": "Name",
   "settings.form.formats.name.description": "Characters authorized: [a-zA-Z0-9_-]",
   "settings.form.formats.x2.label": "Generate x2 version",
+  "settings.form.formats.convertToFormat.label": "Convert To Format",
+  "settings.form.formats.convertToFormat.description": "Convert image to this format",
   "settings.form.formats.width.label": "Width",
   "settings.form.formats.height.label": "Height",
   "settings.form.formats.fit.label": "Fit",

--- a/controllers/validation/settings.js
+++ b/controllers/validation/settings.js
@@ -16,6 +16,7 @@ const settingsSchema = yup.object({
   formats: yup.array().of(yup.object().shape({
     name: yup.string().matches(/^[a-zA-Z0-9_-]+$/gi).required(),
     x2: yup.boolean(),
+    convertToFormat: yup.string().transform(emptyStringToNull).nullable(),
     width: yup.number().required().min(1),
     height: yup.number().min(1).transform(emptyStringToNull).nullable(),
     fit: yup.string(),


### PR DESCRIPTION
Hi there!

Great plugin for Strapi, we are using it in our company to generate some optimized thumbnails.

We've extended it to be able to auto-convert images to `jpg`, `png` or `webp` formats. In our case, converting any `png` images to `jpg` yielded great results - about 80-90% compression on 30 quality.

@nicolashmln What do you think?

![Screenshot from 2021-08-23 17-41-09](https://user-images.githubusercontent.com/5278570/130517410-6727f640-720b-45df-acdc-d36599a1cc44.png)

![Screenshot from 2021-08-23 17-49-14](https://user-images.githubusercontent.com/5278570/130517452-89d183b3-af40-4917-a562-b130aa52d057.png)

![Screenshot from 2021-08-23 17-43-10](https://user-images.githubusercontent.com/5278570/130516752-1d122ccc-3feb-42b5-b4e6-2101d5aa6b10.png)
