### PR TITLE
Fix plugin not working on Strapi v4.6.1 - add support for Strapi v4.6.1

### DIFF
--- a/server/services/image-manipulation.js
+++ b/server/services/image-manipulation.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const { join } = require("path");
 const sharp = require("sharp");
 
-const { bytesToKbytes } = require("@strapi/plugin-upload/server/utils/file");
+const { bytesToKbytes } = require("@strapi/utils/lib/file");
 const { getService } = require("../utils");
 const imageManipulation = require("@strapi/plugin-upload/server/services/image-manipulation");
 


### PR DESCRIPTION
Strapi renamed a file and changed its location. Here's a reference: https://github.com/strapi/strapi/commit/53161238013db79cd34505907a10d8c0238643a4#diff-3b19d2c295bd8d549aafbd9c6366621a7143cfaeb74f870e2199c144c7717eb1