### PR TITLE
Fix import of file lib for Strapi 4.6.1+

### DIFF
--- a/server/services/image-manipulation.js
+++ b/server/services/image-manipulation.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const { join } = require("path");
 const sharp = require("sharp");
 
-const { bytesToKbytes } = require("@strapi/plugin-upload/server/utils/file");
+const { bytesToKbytes } = require('@strapi/utils/lib/file');
 const { getService } = require("../utils");
 const imageManipulation = require("@strapi/plugin-upload/server/services/image-manipulation");
 


### PR DESCRIPTION
Strapi changed the way the file lib in image-manipulation is imported, this should fix it