### PR TITLE
Compatibility to Strapi 4.11.4

### DIFF
--- a/server/services/image-manipulation.js
+++ b/server/services/image-manipulation.js
@@ -6,7 +6,9 @@ const fs = require("fs");
 const { join } = require("path");
 const sharp = require("sharp");
 
-const { bytesToKbytes } = require("@strapi/utils/lib/file");
+const {
+  file: { bytesToKbytes},
+} = require('@strapi/utils');
 const { getService } = require("../utils");
 const imageManipulation = require("@strapi/plugin-upload/server/services/image-manipulation");
 


### PR DESCRIPTION
Unfortunately, Strapi has changed the package/import mechanics again.
This commit restores Compatibility to Strapi ^4.11.4 and fixes https://github.com/nicolashmln/strapi-plugin-responsive-image/issues/38.