### PR TITLE
fix: import `@strapi/upload` components with the newly defined exports since v4.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-responsive-image",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Custom responsive image formats for strapi.",
   "strapi": {
     "name": "responsive-image",
@@ -30,7 +30,7 @@
     "media"
   ],
   "engines": {
-    "node": ">=14.19.1 <=18.x.x",
+    "node": ">=18.0.0 <=20.x.x",
     "npm": ">=8.0.0"
   },
   "license": "MIT"

--- a/server/services/image-manipulation.js
+++ b/server/services/image-manipulation.js
@@ -11,7 +11,8 @@ const {
   file: { bytesToKbytes },
 } = require("@strapi/utils");
 const { getService } = require("../utils");
-const imageManipulation = require("@strapi/plugin-upload/server/services/image-manipulation");
+const pluginUpload = require("@strapi/plugin-upload/strapi-server");
+const imageManipulation = pluginUpload().services["image-manipulation"];
 
 const writeStreamToFile = (stream, path) =>
   new Promise((resolve, reject) => {


### PR DESCRIPTION
fix: import `@strapi/upload` components with the newly defined exports since v4.15.1 (ref: https://github.com/strapi/strapi/pull/18622)
chore(package.json): updated engines to match `@strapi/upload`
chore(version): bumped version

closes #45