### PR TITLE
Fix building on Strapi > 4.15.2

### DIFF
--- a/server/services/image-manipulation.js
+++ b/server/services/image-manipulation.js
@@ -11,7 +11,7 @@ const {
   file: { bytesToKbytes },
 } = require("@strapi/utils");
 const { getService } = require("../utils");
-const imageManipulation = require("@strapi/plugin-upload/server/services/image-manipulation");
+const imageManipulation = require("../../../@strapi/plugin-upload/server/services/image-manipulation");
 
 const writeStreamToFile = (stream, path) =>
   new Promise((resolve, reject) => {


### PR DESCRIPTION
A quick and dirty fix for import causing errors with the new Strapi 4.15.2 build process.
